### PR TITLE
Fix failing docs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! > Polyfill for `is_terminal` stdlib feature for use with older MSRVs
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(clippy::print_stderr)]
 #![warn(clippy::print_stdout)]
 


### PR DESCRIPTION
The `doc_auto_cfg` attribute has been merged into `doc_cfg`
rust-lang/rust#43781